### PR TITLE
Fixed issues related to clients leaving whenever they want

### DIFF
--- a/src/main/java/ch/heigvd/connect4/Connect4Server.java
+++ b/src/main/java/ch/heigvd/connect4/Connect4Server.java
@@ -122,6 +122,7 @@ public class Connect4Server implements Runnable{
                             continue;
                         } else if (opponentLeft) {
                             handleOpponentLeft(bw);
+                            opponentLeft = false;
                             continue;
                         }
                     }
@@ -202,6 +203,7 @@ public class Connect4Server implements Runnable{
                 // Opponent left while waiting
                 if (opponentLeft) {
                     handleOpponentLeft(bw);
+                    opponentLeft = false;
                     return;
                 }
 
@@ -508,9 +510,7 @@ public class Connect4Server implements Runnable{
                 randomAlreadyDone = false;
                 nbOfReady.set(0);
                 turnResult = TurnResult.NOTHING;
-                userTurn = null;
                 newGame = true;
-                opponentLeft = false;
                 state = ClientState.JOIN;
             }
         }
@@ -530,6 +530,8 @@ public class Connect4Server implements Runnable{
                 if (nbClient.get() == 0) {
                     // Reset server state if all clients disconnected
                     resetServerGameStateIfNeeded();
+                    opponentLeft = false;
+                    userTurn = null;
                 }
 
                 disconnectedWhileWaitingForPlayers = false;


### PR DESCRIPTION
This pull request introduces changes to the management of game state in the `Connect4Server` class, specifically focusing on the handling of the `opponentLeft` and `userTurn` variables. The main goal is to ensure these variables are reset appropriately in various scenarios, improving the reliability of server state transitions when clients disconnect or leave.

**Game state management improvements:**

* Ensured `opponentLeft` is reset to `false` immediately after handling an opponent leaving, both during the main game loop and while waiting for a turn, preventing stale state from affecting subsequent game logic.
* Moved the resetting of `opponentLeft` and `userTurn` to the `handleClientDisconnection` method, so these variables are explicitly cleared when all clients disconnect, rather than in `resetServerGameStateIfNeeded`.